### PR TITLE
feat: add interactive front-end for API requests

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1,0 +1,243 @@
+const form = document.querySelector('#transaction-form');
+const jsonPreview = document.querySelector('#json-preview');
+const curlPreview = document.querySelector('#curl-preview');
+const responseSummary = document.querySelector('#response-summary');
+const latencyValue = document.querySelector('#latency-value');
+const historyList = document.querySelector('#history-list');
+const historyTemplate = document.querySelector('#history-item-template');
+const sampleSelect = document.querySelector('#sample-presets');
+const copyCurlButton = document.querySelector('#copy-curl');
+const clearHistoryButton = document.querySelector('#clear-history');
+const toggleThemeButton = document.querySelector('#toggle-theme');
+
+const API_ENDPOINT = '/predict';
+
+const presets = {
+  legit: {
+    step: 4,
+    type: 'TRANSFER',
+    amount: 850.75,
+    oldbalanceOrg: 4500.2,
+    newbalanceOrig: 3649.45,
+    oldbalanceDest: 1200.0,
+    newbalanceDest: 2050.75,
+    nameOrig: 'C123456789',
+    nameDest: 'M99887766',
+    isFlaggedFraud: 0,
+  },
+  fraud: {
+    step: 1,
+    type: 'TRANSFER',
+    amount: 9850.0,
+    oldbalanceOrg: 9850.0,
+    newbalanceOrig: 0.0,
+    oldbalanceDest: 0.0,
+    newbalanceDest: 0.0,
+    nameOrig: 'C882200339',
+    nameDest: 'C332200882',
+    isFlaggedFraud: 1,
+  },
+  small: {
+    step: 12,
+    type: 'PAYMENT',
+    amount: 49.99,
+    oldbalanceOrg: 350.0,
+    newbalanceOrig: 300.01,
+    oldbalanceDest: 1020.0,
+    newbalanceDest: 1069.99,
+    nameOrig: 'C78221',
+    nameDest: 'M00345',
+    isFlaggedFraud: 0,
+  },
+};
+
+function normaliseFormData(formData) {
+  const payload = Object.fromEntries(formData.entries());
+  const numericFields = [
+    'step',
+    'amount',
+    'oldbalanceOrg',
+    'newbalanceOrig',
+    'oldbalanceDest',
+    'newbalanceDest',
+  ];
+
+  for (const field of numericFields) {
+    const value = payload[field];
+    payload[field] = value === '' ? null : Number(value);
+  }
+
+  payload.isFlaggedFraud = form.elements.isFlaggedFraud.checked ? 1 : 0;
+
+  if (!payload.nameOrig) {
+    payload.nameOrig = null;
+  }
+  if (!payload.nameDest) {
+    payload.nameDest = null;
+  }
+
+  return payload;
+}
+
+function formatJson(payload) {
+  return JSON.stringify(payload, null, 2);
+}
+
+function buildCurl(payload) {
+  const escapedJson = formatJson(payload).replace(/"/g, '\\"');
+  return [
+    "curl -X POST 'http://localhost:8000" + API_ENDPOINT + "'",
+    "  -H 'Content-Type: application/json'",
+    "  -d \"" + escapedJson.replace(/\n/g, "\\n") + "\"",
+  ].join('\n');
+}
+
+function updatePreviews() {
+  const payload = normaliseFormData(new FormData(form));
+  jsonPreview.textContent = formatJson(payload);
+  curlPreview.textContent = buildCurl(payload);
+}
+
+function setFormValues(values) {
+  for (const [key, value] of Object.entries(values)) {
+    if (key === 'isFlaggedFraud') {
+      form.elements[key].checked = Boolean(value);
+    } else if (form.elements[key]) {
+      form.elements[key].value = value;
+    }
+  }
+  updatePreviews();
+}
+
+async function submitForm(event) {
+  event.preventDefault();
+  const formData = new FormData(form);
+  const payload = normaliseFormData(formData);
+  const startTime = performance.now();
+
+  try {
+    const response = await fetch(API_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+    const elapsed = performance.now() - startTime;
+    latencyValue.textContent = `${elapsed.toFixed(0)} ms`;
+
+    if (!response.ok) {
+      const detail = await response.json().catch(() => ({}));
+      throw new Error(detail.detail || response.statusText);
+    }
+
+    const result = await response.json();
+    renderSuccess(result, payload);
+  } catch (error) {
+    renderError(error, payload);
+  }
+}
+
+function renderSuccess(result, payload) {
+  const summary = `Prediction: ${result.is_fraud ? 'Fraudulent' : 'Legitimate'} • Probability ${
+    (result.fraud_probability * 100).toFixed(2)
+  }%`;
+  responseSummary.className = 'response-summary success';
+  responseSummary.textContent = summary;
+  addHistoryItem({
+    payload,
+    result: result.is_fraud,
+    probability: result.fraud_probability,
+  });
+}
+
+function renderError(error, payload) {
+  responseSummary.className = 'response-summary error';
+  responseSummary.textContent = `Request failed: ${error.message}`;
+  addHistoryItem({ payload, result: null, probability: null, error: error.message });
+}
+
+function addHistoryItem(entry) {
+  const clone = historyTemplate.content.cloneNode(true);
+  const pill = clone.querySelector('[data-result]');
+  const payloadLabel = clone.querySelector('.payload');
+  const timeEl = clone.querySelector('[data-time]');
+  const probabilityEl = clone.querySelector('.probability');
+
+  payloadLabel.textContent = formatJson(entry.payload).replace(/\s+/g, ' ');
+  timeEl.textContent = new Date().toLocaleTimeString();
+
+  if (entry.result === null) {
+    pill.style.background = 'transparent';
+    pill.style.border = '1px solid var(--negative)';
+    probabilityEl.textContent = 'Error';
+    probabilityEl.style.color = 'var(--negative)';
+  } else {
+    const isFraud = Boolean(entry.result);
+    pill.classList.add(isFraud ? 'negative' : 'positive');
+    probabilityEl.textContent = `${(entry.probability * 100).toFixed(2)}%`;
+    probabilityEl.style.color = isFraud ? 'var(--negative)' : 'var(--positive)';
+  }
+
+  historyList.prepend(clone);
+}
+
+function clearHistory() {
+  historyList.innerHTML = '';
+  responseSummary.className = 'response-summary';
+  responseSummary.innerHTML = '<p>No requests sent yet. Configure the payload and press submit.</p>';
+  latencyValue.textContent = '–';
+}
+
+function restoreCustomValues() {
+  const initialValues = {
+    step: 1,
+    type: 'TRANSFER',
+    amount: 1500,
+    oldbalanceOrg: 2000,
+    newbalanceOrig: 500,
+    oldbalanceDest: 0,
+    newbalanceDest: 1500,
+    nameOrig: '',
+    nameDest: '',
+    isFlaggedFraud: 0,
+  };
+  setFormValues(initialValues);
+}
+
+function handlePresetChange(event) {
+  const value = event.target.value;
+  if (value === 'custom') {
+    restoreCustomValues();
+    return;
+  }
+  setFormValues(presets[value]);
+}
+
+function attachListeners() {
+  form.addEventListener('input', updatePreviews);
+  form.addEventListener('change', updatePreviews);
+  form.addEventListener('submit', submitForm);
+  form.addEventListener('reset', () => {
+    setTimeout(updatePreviews, 0);
+  });
+  sampleSelect.addEventListener('change', handlePresetChange);
+  copyCurlButton.addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(curlPreview.textContent);
+      copyCurlButton.textContent = 'Copied!';
+      setTimeout(() => (copyCurlButton.textContent = 'Copy curl'), 1500);
+    } catch (error) {
+      copyCurlButton.textContent = 'Press Ctrl+C';
+      setTimeout(() => (copyCurlButton.textContent = 'Copy curl'), 1500);
+    }
+  });
+  clearHistoryButton.addEventListener('click', clearHistory);
+  toggleThemeButton.addEventListener('click', () => {
+    document.body.classList.toggle('light');
+  });
+}
+
+restoreCustomValues();
+attachListeners();
+updatePreviews();

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,0 +1,380 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --card-bg: rgba(15, 23, 42, 0.9);
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --surface: rgba(148, 163, 184, 0.1);
+  --border: rgba(148, 163, 184, 0.15);
+  --positive: #22c55e;
+  --negative: #ef4444;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+body.light {
+  --bg: #f8fafc;
+  --card-bg: #ffffff;
+  --text: #0f172a;
+  --muted: #475569;
+  --accent: #2563eb;
+  --accent-strong: #1d4ed8;
+  --surface: rgba(37, 99, 235, 0.06);
+  --border: rgba(15, 23, 42, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.2), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.25), transparent 50%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 2.5rem clamp(1rem, 4vw, 3rem);
+  transition: background 250ms ease, color 250ms ease;
+}
+
+.app-shell {
+  width: min(1200px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+
+.app-header h1 {
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  margin: 0;
+}
+
+.app-header p {
+  margin: 0.5rem 0 0;
+  max-width: 52ch;
+  color: var(--muted);
+}
+
+.content-grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 1.5rem;
+  padding: clamp(1.25rem, 2vw, 1.75rem);
+  border: 1px solid var(--border);
+  box-shadow: 0 24px 80px rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  backdrop-filter: blur(12px);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.card-header p {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+}
+
+.sample-select {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.sample-select select {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: inherit;
+  font: inherit;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.field span {
+  color: var(--muted);
+}
+
+.field input,
+.field select {
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.85rem;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  transition: border 150ms ease, box-shadow 150ms ease;
+}
+
+.field input:focus,
+.field select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+}
+
+.field.toggle {
+  position: relative;
+  align-items: center;
+  grid-template-columns: 1fr auto;
+  background: var(--surface);
+  border-radius: 1rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border);
+}
+
+.field.toggle input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.toggle-slider {
+  width: 46px;
+  height: 24px;
+  background: rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+  position: relative;
+  transition: background 200ms ease;
+}
+
+.toggle-slider::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: white;
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.35);
+  transition: transform 200ms ease;
+}
+
+.field.toggle input:checked + .toggle-slider {
+  background: rgba(34, 197, 94, 0.45);
+}
+
+.field.toggle input:checked + .toggle-slider::after {
+  transform: translateX(22px);
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.button {
+  border-radius: 999px;
+  padding: 0.65rem 1.4rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+
+.button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: white;
+  box-shadow: 0 12px 30px rgba(37, 99, 235, 0.3);
+}
+
+.button.ghost {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: inherit;
+}
+
+.button:hover {
+  transform: translateY(-1px);
+}
+
+.button:active {
+  transform: translateY(1px);
+}
+
+.preview-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.preview-grid article {
+  background: var(--surface);
+  border-radius: 1rem;
+  border: 1px solid var(--border);
+  overflow: hidden;
+}
+
+.preview-grid header {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  border-bottom: 1px solid var(--border);
+}
+
+.preview-grid pre {
+  margin: 0;
+  padding: 1rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text);
+}
+
+.response-summary {
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  min-height: 110px;
+  display: grid;
+  place-content: center;
+  text-align: center;
+  color: var(--muted);
+}
+
+.response-summary.success {
+  border-color: rgba(34, 197, 94, 0.35);
+  color: var(--positive);
+}
+
+.response-summary.error {
+  border-color: rgba(239, 68, 68, 0.45);
+  color: var(--negative);
+}
+
+.latency {
+  display: grid;
+  gap: 0.15rem;
+  text-align: right;
+  color: var(--muted);
+}
+
+.latency strong {
+  color: var(--text);
+  font-size: 1.1rem;
+}
+
+.history {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.history header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.history ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+  max-height: 260px;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.history li {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.9rem;
+  background: rgba(148, 163, 184, 0.15);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  font-size: 0.85rem;
+}
+
+.history li .payload {
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.history li time {
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+}
+
+.history li .probability {
+  font-weight: 600;
+}
+
+.pill {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.pill.positive {
+  background: var(--positive);
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.25);
+}
+
+.pill.negative {
+  background: var(--negative);
+  box-shadow: 0 0 0 4px rgba(239, 68, 68, 0.25);
+}
+
+@media (max-width: 960px) {
+  body {
+    padding: 1.5rem;
+  }
+
+  .card {
+    border-radius: 1.1rem;
+  }
+
+  .history li {
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto;
+    row-gap: 0.4rem;
+  }
+
+  .history li time,
+  .history li .probability {
+    justify-self: flex-start;
+  }
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fraud Detection Playground</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+      rel="preconnect"
+      href="https://fonts.gstatic.com"
+      crossorigin
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="app-header">
+        <div>
+          <h1>Fraud Detection Playground</h1>
+          <p>
+            Experiment with different transaction profiles and instantly preview
+            the request payload, generated <code>curl</code> command, and model
+            predictions from the FastAPI service.
+          </p>
+        </div>
+        <button id="toggle-theme" class="button ghost" type="button">
+          Toggle Theme
+        </button>
+      </header>
+
+      <main class="content-grid">
+        <section class="card" aria-labelledby="transaction-builder">
+          <div class="card-header">
+            <div>
+              <h2 id="transaction-builder">Transaction Builder</h2>
+              <p>Create a payload with granular control over each feature.</p>
+            </div>
+            <div class="sample-select">
+              <label for="sample-presets">Load preset</label>
+              <select id="sample-presets">
+                <option value="custom" selected>Custom values</option>
+                <option value="legit">Legitimate transfer</option>
+                <option value="fraud">Likely fraud</option>
+                <option value="small">Small payment</option>
+              </select>
+            </div>
+          </div>
+
+          <form id="transaction-form" novalidate>
+            <div class="form-grid">
+              <label class="field">
+                <span>Step</span>
+                <input type="number" name="step" min="0" step="1" required />
+              </label>
+              <label class="field">
+                <span>Type</span>
+                <select name="type" required>
+                  <option value="TRANSFER">TRANSFER</option>
+                  <option value="CASH_OUT">CASH_OUT</option>
+                  <option value="CASH_IN">CASH_IN</option>
+                  <option value="DEBIT">DEBIT</option>
+                  <option value="PAYMENT">PAYMENT</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>Amount</span>
+                <input type="number" name="amount" min="0" step="0.01" required />
+              </label>
+              <label class="field">
+                <span>Old Balance (Origin)</span>
+                <input
+                  type="number"
+                  name="oldbalanceOrg"
+                  step="0.01"
+                  required
+                />
+              </label>
+              <label class="field">
+                <span>New Balance (Origin)</span>
+                <input
+                  type="number"
+                  name="newbalanceOrig"
+                  step="0.01"
+                  required
+                />
+              </label>
+              <label class="field">
+                <span>Old Balance (Destination)</span>
+                <input
+                  type="number"
+                  name="oldbalanceDest"
+                  step="0.01"
+                  required
+                />
+              </label>
+              <label class="field">
+                <span>New Balance (Destination)</span>
+                <input
+                  type="number"
+                  name="newbalanceDest"
+                  step="0.01"
+                  required
+                />
+              </label>
+              <label class="field">
+                <span>Name (Origin)</span>
+                <input type="text" name="nameOrig" placeholder="Optional" />
+              </label>
+              <label class="field">
+                <span>Name (Destination)</span>
+                <input type="text" name="nameDest" placeholder="Optional" />
+              </label>
+              <label class="field toggle">
+                <span>Flagged as Fraud</span>
+                <input type="checkbox" name="isFlaggedFraud" />
+                <span class="toggle-slider" aria-hidden="true"></span>
+              </label>
+            </div>
+
+            <div class="form-actions">
+              <button class="button primary" type="submit">
+                Send to FastAPI
+              </button>
+              <button class="button ghost" type="reset">Reset</button>
+            </div>
+          </form>
+        </section>
+
+        <section class="card" aria-labelledby="payload-preview">
+          <div class="card-header">
+            <div>
+              <h2 id="payload-preview">Payload &amp; Curl Preview</h2>
+              <p>Everything updates live as you tweak the form.</p>
+            </div>
+            <button id="copy-curl" class="button ghost" type="button">
+              Copy curl
+            </button>
+          </div>
+          <div class="preview-grid">
+            <article>
+              <header>JSON Payload</header>
+              <pre id="json-preview" aria-live="polite"></pre>
+            </article>
+            <article>
+              <header>curl Command</header>
+              <pre id="curl-preview" aria-live="polite"></pre>
+            </article>
+          </div>
+        </section>
+
+        <section class="card" aria-labelledby="response-inspector">
+          <div class="card-header">
+            <div>
+              <h2 id="response-inspector">Response Inspector</h2>
+              <p>Monitor request status, latency, and prediction history.</p>
+            </div>
+            <div class="latency">
+              <span>Latency</span>
+              <strong id="latency-value">–</strong>
+            </div>
+          </div>
+          <div class="response-summary" id="response-summary">
+            <p>No requests sent yet. Configure the payload and press submit.</p>
+          </div>
+          <div class="history">
+            <header>
+              <h3>History</h3>
+              <button id="clear-history" class="button ghost" type="button">
+                Clear
+              </button>
+            </header>
+            <ul id="history-list" aria-live="polite"></ul>
+          </div>
+        </section>
+      </main>
+    </div>
+
+    <template id="history-item-template">
+      <li>
+        <div class="pill" data-result></div>
+        <div class="payload"></div>
+        <time data-time></time>
+        <span class="probability"></span>
+      </li>
+    </template>
+
+    <script src="/static/app.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a modern HTML dashboard with presets, live payload previews, and response history for crafting FastAPI prediction requests
- create dedicated CSS and JavaScript assets to drive theming, validation, curl generation, and clipboard utilities
- mount static/template assets in the FastAPI app and expose a root route for the playground UI

## Testing
- pytest
